### PR TITLE
fix: Update Dockerfile to work with mybinder.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,60 @@
-FROM jupyter/base-notebook:latest
-
-# Install .NET CLI dependencies
-
-ARG NB_USER=jovyan
-ARG NB_UID=1000
-ENV USER ${NB_USER}
-ENV NB_UID ${NB_UID}
-ENV HOME /home/${NB_USER}
-
-WORKDIR ${HOME}
-
-USER root
-RUN apt-get update
-RUN apt-get install -y curl
+ARG REPO=mcr.microsoft.com/dotnet/runtime
+FROM $REPO:6.0.22-jammy-amd64 AS dotnet-cli
 
 ENV \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true \
-    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_SDK_VERSION=6.0.414 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
     # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
     DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
 
-# Install .NET CLI dependencies
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu66 \
-        libssl1.1 \
-        libstdc++6 \
-        zlib1g \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends \
+        curl \
+	git \
+	wget \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install .NET Core SDK
-
-# When updating the SDK version, the sha512 value a few lines down must also be updated.
-ENV DOTNET_SDK_VERSION 6.0.403
-
-RUN dotnet_sdk_version=6.0.403 \
-    && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-    && dotnet_sha512='779b3e24a889dbb517e5ff5359dab45dd3296160e4cb5592e6e41ea15cbf87279f08405febf07517aa02351f953b603e59648550a096eefcb0a20fdaf03fadde' \
-    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
+# Install .NET SDK
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+    && dotnet_sha512='79bb0576df990bb1bdb2008756587fbf6068562887b67787f639fa51cf1a73d06a7272a244ef34de627dee4bb82377f91f49de9994cbaeb849412df4e711db40' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
     && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
     # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
-# Copy notebooks
 
-COPY ./notebooks/ ${HOME}/notebooks/
+FROM jupyter/base-notebook:ubuntu-22.04
+
+
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ENV USER ${NB_USER}
+ENV NV_UID ${NB_UID}
+ENV HOME /home/${NB_USER}
+
+# Copy Notebooks
+COPY notebooks ${HOME}/notebooks
 
 # Copy package sources
+COPY nugetprops.config ${HOME}/nuget.config
 
-COPY ./nugetprops.config ${HOME}/nuget.config
+USER root
+COPY --from=dotnet-cli ["/usr/share/dotnet", "/usr/share/dotnet"]
+RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+RUN chown -R ${NB_UID} ${HOME} 
+USER ${NB_USER}
 
-RUN chown -R ${NB_UID} ${HOME}
-USER ${USER}
-
-#Install nteract 
-RUN pip install nteract_on_jupyter
+# Install nteract
+RUN python3 -m pip install --no-cache-dir nteract-on-jupyter
 
 # Install lastest build from master branch of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+# RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 
 #latest stable from nuget.org
+RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.446104
 #RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"
 
 ENV PATH="${PATH}:${HOME}/.dotnet/tools"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,14 @@ RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/
 
 FROM jupyter/base-notebook:ubuntu-22.04
 
+ENV \
+    DOTNET_RUNNING_IN_DOCKER=true \
+    DOTNET_USER_POLLING_FILE_WATCHER=true \
+    NUGET_XMLDOC_MODE=skip \
+    # Otherwise, dotnet-interactive expects some cultural-specific data, which entails installing `libicu`
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true \
+    # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
+    DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000
@@ -50,13 +58,6 @@ RUN python3 -m pip install --no-cache-dir nteract-on-jupyter
 
 # Install lastest build from master branch of Microsoft.DotNet.Interactive
 # RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
-
-ENV \
-    DOTNET_RUNNING_IN_DOCKER=true \
-    DOTNET_USER_POLLING_FILE_WATCHER=true \
-    NUGET_XMLDOC_MODE=skip \
-    # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
-    DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
 
 #latest stable from nuget.org
 RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.446104

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ FROM $REPO:6.0.22-jammy-amd64 AS dotnet-cli
 ENV \
     DOTNET_SDK_VERSION=6.0.414 \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
-    NUGET_XMLDOC_MODE=skip \
-    # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
-    DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
+    NUGET_XMLDOC_MODE=skip
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -52,6 +50,13 @@ RUN python3 -m pip install --no-cache-dir nteract-on-jupyter
 
 # Install lastest build from master branch of Microsoft.DotNet.Interactive
 # RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+
+ENV \
+    DOTNET_RUNNING_IN_DOCKER=true \
+    DOTNET_USER_POLLING_FILE_WATCHER=true \
+    NUGET_XMLDOC_MODE=skip \
+    # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
+    DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
 
 #latest stable from nuget.org
 RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.446104

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-ARG REPO=mcr.microsoft.com/dotnet/runtime
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
 FROM $REPO:6.0.22-jammy-amd64 AS dotnet-cli
 
 ENV \
+    # Unset ASPNETCORE_URLS from base image
+    ASPNETCORE_URLS= \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # SDK version
     DOTNET_SDK_VERSION=6.0.414 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
 RUN apt-get update \
@@ -28,9 +35,13 @@ FROM jupyter/base-notebook:ubuntu-22.04
 
 ENV \
     DOTNET_RUNNING_IN_DOCKER=true \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USER_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip \
-    # Otherwise, dotnet-interactive expects some cultural-specific data, which entails installing `libicu`
+    # `dotnet-interactive` expects some cultural-specific data, which entails installing `libicu`
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true \
     # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
     DOTNET_CLI_TELEMETRY_OPTOUT=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,6 @@ RUN ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 RUN chown -R ${NB_UID} ${HOME} 
 USER ${NB_USER}
 
-# Install nteract
-RUN mamba install --yes 'nteract-on-jupyter' \
-    && mamba clean --all -f -y
-
 # Install lastest build from master branch of Microsoft.DotNet.Interactive
 # RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:6.0.22-jammy-amd64 AS dotnet-cli
+FROM $REPO:7.0.11-jammy-amd64 AS dotnet-cli
 
 ENV \
     # Unset ASPNETCORE_URLS from base image
@@ -7,7 +7,7 @@ ENV \
     # Do not generate certificate
     DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
     # SDK version
-    DOTNET_SDK_VERSION=6.0.414 \
+    DOTNET_SDK_VERSION=7.0.401 \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
@@ -25,7 +25,7 @@ RUN apt-get update \
 
 # Install .NET SDK
 RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
-    && dotnet_sha512='79bb0576df990bb1bdb2008756587fbf6068562887b67787f639fa51cf1a73d06a7272a244ef34de627dee4bb82377f91f49de9994cbaeb849412df4e711db40' \
+    && dotnet_sha512='2544f58c7409b1fd8fe2c7f600f6d2b6a1929318071f16789bd6abf6deea00bd496dd6ba7f2573bbf17c891c4f56a372a073e57712acfd3e80ea3eb1b3f9c3d0' \
     && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
     && mkdir -p /usr/share/dotnet \
     && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
@@ -65,8 +65,8 @@ USER ${NB_USER}
 # Install lastest build from master branch of Microsoft.DotNet.Interactive
 # RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 
-# Latest stable for net6.0 from nuget.org
-RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.355307
+# Latest stable for net7.0 from nuget.org
+RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.446104
 
 ENV PATH="${PATH}:${HOME}/.dotnet/tools"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV \
     # Otherwise, dotnet-interactive expects some cultural-specific data, which entails installing `libicu`
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true \
     # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
-    DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
+    DOTNET_CLI_TELEMETRY_OPTOUT=true
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000
@@ -60,7 +60,7 @@ RUN python3 -m pip install --no-cache-dir nteract-on-jupyter
 # RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 
 #latest stable from nuget.org
-RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.446104
+RUN dotnet tool install -g Microsoft.dotnet-interactive --version 1.0.355307
 #RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"
 
 ENV PATH="${PATH}:${HOME}/.dotnet/tools"
@@ -70,7 +70,7 @@ RUN echo "$PATH"
 RUN dotnet interactive jupyter install
 
 # Enable telemetry once we install jupyter for the image
-ENV DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=false
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=false
 
 # Set root to notebooks
 WORKDIR ${HOME}/notebooks/


### PR DESCRIPTION
I noticed the interactive notebook linked in the `README` wasn't building, so I pretty much overhauled the `Dockerfile`.

Basically, `dotnet-interactive` only works with net7.0 now and needs ASP.NET, so I updated the installation accordingly. I also didn't see how `nteract` was used in the demo, so I removed the installation for a smaller Docker build. You can view the notebook running here: https://mybinder.org/v2/gh/moonshxne/Mondocks/my-binder